### PR TITLE
050-swift-storage.conf: "guid" should be "gid"

### DIFF
--- a/templates/050-swift-storage.conf
+++ b/templates/050-swift-storage.conf
@@ -1,6 +1,6 @@
 [account]
 uid = swift
-guid = swift
+gid = swift
 max connections = {{ account_max_connections }}
 path = /srv/node/
 read only = false
@@ -11,7 +11,7 @@ hosts allow = {{ allowed_hosts }}
 
 [container]
 uid = swift
-guid = swift
+gid = swift
 max connections = {{ container_max_connections }}
 path = /srv/node/
 read only = false
@@ -22,7 +22,7 @@ hosts allow = {{ allowed_hosts }}
 
 [object]
 uid = swift
-guid = swift
+gid = swift
 max connections = {{ object_max_connections }}
 path = /srv/node/
 read only = false


### PR DESCRIPTION
fixes group ownership, and also stops logging a warning on every rsync connection