### PR TITLE
Fixed rsyncd.conf template, there's no such thing as guid.

### DIFF
--- a/templates/050-swift-storage.conf
+++ b/templates/050-swift-storage.conf
@@ -1,6 +1,6 @@
 [account]
 uid = swift
-guid = swift
+gid = swift
 max connections = {{ account_max_connections }}
 path = /srv/node/
 read only = false
@@ -11,7 +11,7 @@ hosts allow = {{ allowed_hosts }}
 
 [container]
 uid = swift
-guid = swift
+gid = swift
 max connections = {{ container_max_connections }}
 path = /srv/node/
 read only = false
@@ -22,7 +22,7 @@ hosts allow = {{ allowed_hosts }}
 
 [object]
 uid = swift
-guid = swift
+gid = swift
 max connections = {{ object_max_connections }}
 path = /srv/node/
 read only = false


### PR DESCRIPTION
Reduce rsyncd logging noise:

Mar 22 01:17:41 asclepi object-replicator: Starting object replication pass.
Mar 22 01:17:53 asclepi rsyncd[14348]: Unknown Parameter encountered: "guid"
Mar 22 01:17:53 asclepi rsyncd[14348]: IGNORING unknown parameter "guid"
Mar 22 01:17:53 asclepi rsyncd[14348]: Unknown Parameter encountered: "guid"
Mar 22 01:17:53 asclepi rsyncd[14348]: IGNORING unknown parameter "guid"
Mar 22 01:17:53 asclepi rsyncd[14348]: Unknown Parameter encountered: "guid"
Mar 22 01:17:53 asclepi rsyncd[14348]: IGNORING unknown parameter "guid"